### PR TITLE
Change _send_custom_command.

### DIFF
--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -1,6 +1,7 @@
 """Python Package for controlling the zoom of Kurokesu's camera."""
 
 import serial
+import time
 
 
 class ZoomController:
@@ -18,14 +19,14 @@ class ZoomController:
 
     zoom_pos = {
         'left': {
-            'in': {'zoom': 401, 'focus': 168},
-            'inter': {'zoom': 200, 'focus': 358},
-            'out': {'zoom': 33, 'focus': 358},
+            'in': {'zoom': 457, 'focus': 70},
+            'inter': {'zoom': 270, 'focus': 331},
+            'out': {'zoom': 0, 'focus': 455},
         },
         'right': {
-            'in': {'zoom': 401, 'focus': 40},
-            'inter': {'zoom': 200, 'focus': 425},
-            'out': {'zoom': 33, 'focus': 500},
+            'in': {'zoom': 457, 'focus': 42},
+            'inter': {'zoom': 270, 'focus': 321},
+            'out': {'zoom': 0, 'focus': 445},
         },
     }
 

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -47,8 +47,8 @@ class ZoomController:
         if response.decode() != 'ok\r\n':
             raise IOError('Initialization of zoom controller failed, check that the control board is correctly plugged in.')
 
-    def send_zoom_command(self, side: str, zoom_level: str) -> None:
-        """Send a zoom command.
+    def set_zoom_level(self, side: str, zoom_level: str) -> None:
+        """Set zoom level of a given camera.
 
         Given the camera side and the zoom level required,
         produce the corresponding G-code and send it over the serial port.

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -17,9 +17,16 @@ class ZoomController:
     }
 
     zoom_pos = {
-        'in': {'zoom': 500, 'focus': 20},
-        'inter': {'zoom': 350, 'focus': 320},
-        'out': {'zoom': 50, 'focus': 500}
+        'left': {
+            'in': {'zoom': 401, 'focus': 168},
+            'inter': {'zoom': 200, 'focus': 358},
+            'out': {'zoom': 33, 'focus': 358},
+        },
+        'right': {
+            'in': {'zoom': 401, 'focus': 40},
+            'inter': {'zoom': 200, 'focus': 425},
+            'out': {'zoom': 33, 'focus': 500},
+        },
     }
 
     def __init__(
@@ -51,7 +58,7 @@ class ZoomController:
                  objects, 'out' for close objects, 'inter' is in between
                  'in' and 'out' levels
         """
-        zoom, focus = self.zoom_pos[zoom_level].values()
+        zoom, focus = self.zoom_pos[side][zoom_level].values()
         self._send_custom_command(side, zoom, focus)
 
     def _send_custom_command(self, side: str, zoom: int, focus: int):

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -3,6 +3,8 @@
 import serial
 import time
 
+from typing import List
+
 
 class ZoomController:
     """Zoom controller class."""
@@ -60,74 +62,28 @@ class ZoomController:
                  'in' and 'out' levels
         """
         zoom, focus = self.zoom_pos[side][zoom_level].values()
-        self._send_custom_command(side, zoom, focus)
+        self._send_custom_command({side: {'zoom': zoom, 'focus': focus}})
 
-    def send_zoom_command_two_cameras(self, left_zoom: str, right_zoom: str) -> None:
-        """Send a zoom command to both cameras in a same time.
-
-        Given the zoom level required to each cameras,
-        produce the corresponding G-code and send it over the serial port.
+    def _send_custom_command(self, commands: dict):
+        """Send custom command to camera controller.
 
         Args:
-            left_zoom: either 'in', 'inter' or 'out'. 'in' level for far
-                 objects, 'out' for close objects, 'inter' is in between
-                 'in' and 'out' levels
-            right_zoom: either 'in', 'inter' or 'out'. 'in' level for far
-                 objects, 'out' for close objects, 'inter' is in between
-                 'in' and 'out' levels
+            commands: dictionnary containing the requested camera name along
+            with requested focus and zoom value. Instructions for both cameras
+            can be sent in one call of this method.
         """
-        val_left = self.zoom_pos["left"][left_zoom]["zoom"]
-        val_right = self.zoom_pos["right"][right_zoom]["zoom"]
-        self.send_custom_zoom_two_cameras(val_left, val_right)
-
-    def _send_custom_command(self, side: str, zoom: int, focus: int):
-            mot = self.motors[self.connector[side]]
-            command = f'G1 {mot["zoom"]}{zoom} F{self.speed}'
-            self.ser.write(bytes(command + '\n', 'utf8'))
-            _ = self.ser.readline()
-            command = f'G1 {mot["focus"]}{focus} F{self.speed}'
-            self.ser.write(bytes(command + '\n', 'utf8'))
-            _ = self.ser.readline()
-
-    def send_custom_zoom_two_cameras(self, left_zoom: int, right_zoom: int):
-        """Send custom zoom values to both cameras.
-
-        Given left and right zoom value,
-        produce the corresponding G-code and send it over the serial port.
-        motors will move at once
-
-        Args:
-            left_zoom: int between 0 and 600
-            right_zoom: int between 0 and 600
-        """
-        if not (0 <= left_zoom <= 600 or 0 <= right_zoom <= 600):
-            raise ValueError('Zoom value must be between 0 and 600.')
-
-        mot_l = self.motors[self.connector['left']]
-        mot_r = self.motors[self.connector['right']]
-        command = f'G1 {mot_l["zoom"]}{left_zoom} {mot_r["zoom"]}{right_zoom} F{self.speed}'
-        self.ser.write(bytes(command + '\n', 'utf8'))
-        _ = self.ser.readline()
-
-    def send_custom_focus_two_cameras(self, left_focus: int, right_focus: int):
-        """Send custom focus values to both cameras.
-
-        Given left and right focus value,
-        produce the corresponding G-code and send it over the serial port.
-        motors will move at once
-
-        Args:
-            left_focus: int between 0 and 600
-            right_focus: int between 0 and 600
-        """
-        if not (0 <= left_focus <= 500 or 0 <= right_focus <= 500):
-            raise ValueError('Zoom value must be between 0 and 500.')
-
-        mot_l = self.motors[self.connector['left']]
-        mot_r = self.motors[self.connector['right']]
-        command = f'G1 {mot_l["focus"]}{left_focus} {mot_r["focus"]}{right_focus} F{self.speed}'
-        self.ser.write(bytes(command + '\n', 'utf8'))
-        _ = self.ser.readline()
+        for side, cmd in commands.items():
+            if side not in ['left', 'right']:
+                print("Keys should be either 'left' or 'right'.")
+                return
+            motor = self.motors[self.connector[side]]
+            for target, value in cmd.items():
+                if target not in ['zoom', 'focus']:
+                    print("Each command should be either on 'focus' or 'zoom'.")
+                    return
+                command = f'G1 {motor[target]}{value} F{self.speed}'
+                self.ser.write(bytes(command + '\n', 'utf8'))
+                _ = self.ser.readline()
 
     def homing(self, side: str) -> None:
         """Use serial port to perform homing sequence on given camera.
@@ -141,10 +97,9 @@ class ZoomController:
         self.ser.write(bytes(cmd + '\n', 'utf8'))
         _ = self.ser.readline()
         time.sleep(0.1)
-
-        self._send_custom_command(side, 0, -500)
+        self._send_custom_command({side: {'zoom': 0, 'focus': -500}})
         time.sleep(1)
-        self._send_custom_command(side, -600, -500)
+        self._send_custom_command({side: {'zoom': -600, 'focus': -500}})
         time.sleep(1)
 
         cmd = 'G92 ' + mot['zoom'] + '0 ' + mot['focus'] + '0'

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -62,9 +62,67 @@ class ZoomController:
         zoom, focus = self.zoom_pos[side][zoom_level].values()
         self._send_custom_command(side, zoom, focus)
 
+    def send_zoom_command_two_cameras(self, left_zoom: str, right_zoom: str) -> None:
+        """Send a zoom command to both cameras in a same time.
+
+        Given the zoom level required to each cameras,
+        produce the corresponding G-code and send it over the serial port.
+
+        Args:
+            left_zoom: either 'in', 'inter' or 'out'. 'in' level for far
+                 objects, 'out' for close objects, 'inter' is in between
+                 'in' and 'out' levels
+            right_zoom: either 'in', 'inter' or 'out'. 'in' level for far
+                 objects, 'out' for close objects, 'inter' is in between
+                 'in' and 'out' levels
+        """
+        val_left = self.zoom_pos["left"][left_zoom]["zoom"]
+        val_right = self.zoom_pos["right"][right_zoom]["zoom"]
+        self.send_custom_zoom_two_cameras(val_left, val_right)
+
     def _send_custom_command(self, side: str, zoom: int, focus: int):
         mot = self.motors[self.connector[side]]
         command = f'G1 {mot["zoom"]}{zoom} {mot["focus"]}{focus} F{self.speed}'
+        self.ser.write(bytes(command + '\n', 'utf8'))
+        _ = self.ser.readline()
+
+    def send_custom_zoom_two_cameras(self, left_zoom: int, right_zoom: int):
+        """Send custom zoom values to both cameras.
+
+        Given left and right zoom value,
+        produce the corresponding G-code and send it over the serial port.
+        motors will move at once
+
+        Args:
+            left_zoom: int between 0 and 600
+            right_zoom: int between 0 and 600
+        """
+        if not (0 <= left_zoom <= 600 or 0 <= right_zoom <= 600):
+            raise ValueError('Zoom value must be between 0 and 600.')
+
+        mot_l = self.motors[self.connector['left']]
+        mot_r = self.motors[self.connector['right']]
+        command = f'G1 {mot_l["zoom"]}{left_zoom} {mot_r["zoom"]}{right_zoom} F{self.speed}'
+        self.ser.write(bytes(command + '\n', 'utf8'))
+        _ = self.ser.readline()
+
+    def send_custom_focus_two_cameras(self, left_focus: int, right_focus: int):
+        """Send custom focus values to both cameras.
+
+        Given left and right focus value,
+        produce the corresponding G-code and send it over the serial port.
+        motors will move at once
+
+        Args:
+            left_focus: int between 0 and 600
+            right_focus: int between 0 and 600
+        """
+        if not (0 <= left_focus <= 500 or 0 <= right_focus <= 500):
+            raise ValueError('Zoom value must be between 0 and 500.')
+
+        mot_l = self.motors[self.connector['left']]
+        mot_r = self.motors[self.connector['right']]
+        command = f'G1 {mot_l["focus"]}{left_focus} {mot_r["focus"]}{right_focus} F{self.speed}'
         self.ser.write(bytes(command + '\n', 'utf8'))
         _ = self.ser.readline()
 

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -81,10 +81,13 @@ class ZoomController:
         self.send_custom_zoom_two_cameras(val_left, val_right)
 
     def _send_custom_command(self, side: str, zoom: int, focus: int):
-        mot = self.motors[self.connector[side]]
-        command = f'G1 {mot["zoom"]}{zoom} {mot["focus"]}{focus} F{self.speed}'
-        self.ser.write(bytes(command + '\n', 'utf8'))
-        _ = self.ser.readline()
+            mot = self.motors[self.connector[side]]
+            command = f'G1 {mot["zoom"]}{zoom} F{self.speed}'
+            self.ser.write(bytes(command + '\n', 'utf8'))
+            _ = self.ser.readline()
+            command = f'G1 {mot["focus"]}{focus} F{self.speed}'
+            self.ser.write(bytes(command + '\n', 'utf8'))
+            _ = self.ser.readline()
 
     def send_custom_zoom_two_cameras(self, left_zoom: int, right_zoom: int):
         """Send custom zoom values to both cameras.

--- a/zoom_kurokesu/zoom_piloting.py
+++ b/zoom_kurokesu/zoom_piloting.py
@@ -70,7 +70,8 @@ class ZoomController:
         Args:
             commands: dictionnary containing the requested camera name along
             with requested focus and zoom value. Instructions for both cameras
-            can be sent in one call of this method.
+            can be sent in one call of this method. However, instructions will
+            be sent sequentially and there is no synchronization.
         """
         for side, cmd in commands.items():
             if side not in ['left', 'right']:


### PR DESCRIPTION
_send_custom_command_ now takes as argument a dictionary with the requested camera and zoom/focus instead. We can use it once for both cameras now.